### PR TITLE
Now context menu for invite-a-teacher link is disabled

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -33,7 +33,8 @@
                 <li> <%= link_to "Добавить группу", new_course_path %> </li>
                 <li> <%= link_to "Все группы", courses_path %> </li>
                 <li class="divider"></li>
-                <li> <%= link_to "Пригласить преподавателя", new_invitation_path,  {:remote => true, 'data-toggle' =>  "modal", 'data-target' => '#modal-window'} %> </li>
+                <li > <%= link_to "Пригласить преподавателя", new_invitation_path, oncontextmenu: "return false",
+                                  remote: true, 'data-toggle': "modal", 'data-target': '#modal-window' %> </li>
               </ul>
             </li>
 


### PR DESCRIPTION
It is impossible now to open the link in a new tab and to get an error